### PR TITLE
fix factory

### DIFF
--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     users_visibility { "all" }
 
     trait :bultin do
-      builtin true
+      builtin { true }
     end
 
     trait :manager do


### PR DESCRIPTION
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

builtin { true }