### PR TITLE
Require development dependencies

### DIFF
--- a/lib/ryspec/version.rb
+++ b/lib/ryspec/version.rb
@@ -1,3 +1,3 @@
 module Ryspec
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/init_factory_bot.rb
+++ b/spec/init_factory_bot.rb
@@ -1,3 +1,4 @@
+require "factory_bot_rails"
 # To prevent loading factories from old core
 FactoryBot.definition_file_paths = []
 FactoryBot.reset_configuration

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ require_relative 'init_factory_bot'
 require_relative 'init_capybara'
 require_relative 'init_support'
 
+require 'database_cleaner'
+
 ActiveJob::Base.queue_adapter = :test
 
 RSpec.configure do |config|


### PR DESCRIPTION
Because when RYS is used for clean Redmine, there is no require of factory_bot or database_cleaner, so constants missing...