### PR TITLE
fix require factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.4.1] - 2021-08-25
+### Fixed
+- correct name argument in requires factories
+- load file instead of require
+### Changed
+- add ".rb" extensions automatically if needs (require factories)
+
 ## [0.4.0] - 2021-07-09
 ### Added
 - Shortcut for require factories from redmine plugins

--- a/lib/ryspec.rb
+++ b/lib/ryspec.rb
@@ -13,10 +13,12 @@ module Ryspec
     factory_name ||= file_name || plugin_name
     return if FactoryBot.factories.registered? factory_name
 
-    factory_file = File.join(Redmine::Plugin.find(name).directory, "/test/factories/#{file_name || plugin_name}")
+    factory_file_name = file_name || plugin_name
+    factory_file_name << ".rb" unless factory_file_name.end_with?(".rb")
+    factory_file = File.join(Redmine::Plugin.find(plugin_name).directory, "/test/factories/#{factory_file_name}")
     raise ArgumentError, "File `#{factory_file}` doesnt exists!" unless File.exist?(factory_file)
 
-    require factory_file
+    load factory_file
   end
 
 end

--- a/lib/ryspec/version.rb
+++ b/lib/ryspec/version.rb
@@ -1,5 +1,5 @@
 module Ryspec
 
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 
 end


### PR DESCRIPTION
1. Wrong argument name - it was renamed but usage was not changed...
2. Factories are required, but RYSpec clear all paths and then load again => this mechanism caused that require was already done and another require is `false` => so instead of require I use `load`
3. allow pass filename with OR without extname