### PR TITLE
capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- pass chrome_options as capabilities
+
 ### Added
 - shoulda-matchers support
 

--- a/spec/init_capybara.rb
+++ b/spec/init_capybara.rb
@@ -26,7 +26,7 @@ end
 
 Capybara.register_driver :chrome do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new(args: CHROME_OPTIONS)
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: chrome_options)
 end
 
 Capybara.register_driver :chrome_headless do |app|
@@ -37,7 +37,7 @@ Capybara.register_driver :chrome_headless do |app|
   args << "window-size=#{RESOLUTION.join(',')}"
 
   chrome_options = Selenium::WebDriver::Chrome::Options.new(args: args)
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: chrome_options)
 end
 
 Capybara.javascript_driver = JS_DRIVER


### PR DESCRIPTION
fixes a warning
```
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```