### PR TITLE
Add retry to capybara specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - pass chrome_options as capabilities
+- Add retry to capybara specs
 
 ### Added
 - shoulda-matchers support

--- a/lib/ryspec/version.rb
+++ b/lib/ryspec/version.rb
@@ -1,5 +1,5 @@
 module Ryspec
 
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,4 +77,8 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter = :test
   end
 
+  config.around :each, js: true do |ex|
+    ex.run_with_retry retry: 3
+  end
+
 end


### PR DESCRIPTION
It should to fix Rys capybara tests that failed by timeout, for ex https://git.easy.cz/rysy/features/xapian_easy_search/-/jobs/1959078
