### PR TITLE
update chrome options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.5.6] - 2022-08-26
+## [0.5.6] - 2023-06-27
 - pass chrome_options as options
 
 ## [0.5.5] - 2022-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.5.6] - 2022-08-26
+- pass chrome_options as options
+
 ## [0.5.5] - 2022-08-26
 ### Fixed
 * rspec_junit_formatter is back | [@pavel](https://git.easy.cz/pavel)

--- a/lib/ryspec/version.rb
+++ b/lib/ryspec/version.rb
@@ -1,5 +1,5 @@
 module Ryspec
 
-  VERSION = '0.5.5'
+  VERSION = '0.5.6'
 
 end

--- a/spec/init_capybara.rb
+++ b/spec/init_capybara.rb
@@ -26,7 +26,7 @@ end
 
 Capybara.register_driver :chrome do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new(args: CHROME_OPTIONS)
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: chrome_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
 end
 
 Capybara.register_driver :chrome_headless do |app|
@@ -37,7 +37,7 @@ Capybara.register_driver :chrome_headless do |app|
   args << "window-size=#{RESOLUTION.join(',')}"
 
   chrome_options = Selenium::WebDriver::Chrome::Options.new(args: args)
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: chrome_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
 end
 
 Capybara.javascript_driver = JS_DRIVER


### PR DESCRIPTION
fixes

2023-06-27 18:50:19 WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead.